### PR TITLE
fix: Sidebarボタンが重複して表示される

### DIFF
--- a/harmonie/Views/Friend/FriendsListView+ToolbarContent.swift
+++ b/harmonie/Views/Friend/FriendsListView+ToolbarContent.swift
@@ -10,11 +10,11 @@ import VRCKit
 
 extension FriendsListView {
     @ToolbarContentBuilder var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .navigation) { presentSheetButton }
+        ToolbarItem(placement: .navigationBarTrailing) { presentSheetButton }
     }
 
     private var presentSheetButton: some View {
-        Button("", systemImage: "sidebar.leading") {
+        Button("", systemImage: IconSet.dots.systemName) {
             isPresentedSheet.toggle()
         }
     }


### PR DESCRIPTION
iPadのような環境では、すでにNavigationSplitViewによってSidebarボタンが存在します。
したがって、このボタンの位置を右に変更し、アイコンを変えて混乱を防ぎます。

before
![telegram-cloud-document-5-6215027898781275007](https://github.com/user-attachments/assets/2f90afa3-850d-47ae-b9eb-70072221c815)

after
![telegram-cloud-document-5-6215027898781275006](https://github.com/user-attachments/assets/73155f7c-9f91-4e66-bf9b-d682f231db84)
